### PR TITLE
Setting default ecs AMI to latest amazon2 ecs optimized image

### DIFF
--- a/groups/infrastructure/profiles/development-eu-west-2/cidev/vars
+++ b/groups/infrastructure/profiles/development-eu-west-2/cidev/vars
@@ -13,3 +13,4 @@ internal_top_level_domain = "-cidev.development.aws.internal"
 
 ec2_key_pair_name = "chs-cidev"
 
+ec2_image_id = "ami-04018f95156d810bc" # ECS optimized Amazon2 Linux in London created 15/03/2023


### PR DESCRIPTION
As part of the AMI upgrade for ECS migration, this is the selected AMI based on the investigation to use EC2 service type on ECS clusters. https://companieshouse.atlassian.net/wiki/spaces/COM/pages/4119134240/AMI+Upgrade. This has been added as a default for now and will set as a data lookup in the future