### PR TITLE
Add overnight scale down of cluster for staging env

### DIFF
--- a/groups/infrastructure/main.tf
+++ b/groups/infrastructure/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "ecs-cluster" {
-  source = "git@github.com:companieshouse/terraform-library-ecs-cluster.git?ref=1.1.4"
+  source = "git@github.com:companieshouse/terraform-library-ecs-cluster.git?ref=1.1.5"
 
   stack_name                 = local.stack_name
   name_prefix                = local.name_prefix
@@ -32,6 +32,8 @@ module "ecs-cluster" {
   asg_min_instance_count     = var.asg_min_instance_count
   enable_container_insights  = var.enable_container_insights
   asg_desired_instance_count = var.asg_desired_instance_count
+  scaledown_schedule         = var.asg_scaledown_schedule
+  scaleup_schedule           = var.asg_scaleup_schedule
 }
 
 module "secrets" {

--- a/groups/infrastructure/profiles/staging-eu-west-2/staging/vars
+++ b/groups/infrastructure/profiles/staging-eu-west-2/staging/vars
@@ -18,3 +18,5 @@ ec2_instance_type = "t3.medium"
 asg_max_instance_count = 3 # allow staging to scale up
 asg_min_instance_count = 1 # allow staging to scale down
 asg_desired_instance_count = 2 # keep staging small by default
+asg_scaledown_schedule = "00 20 * * 1-7"
+asg_scaleup_schedule = "00 06 * * 1-7"

--- a/groups/infrastructure/variables.tf
+++ b/groups/infrastructure/variables.tf
@@ -65,6 +65,18 @@ variable "asg_desired_instance_count" {
   description = "The desired number of instances in the autoscaling group for the cluster. Must fall within the min/max instance count range."
 }
 
+variable "asg_scaledown_schedule" {
+  default     = ""
+  type        = string
+  description = "The schedule to use when scaling down the number of EC2 instances to zero."
+}
+
+variable "asg_scaleup_schedule" {
+  default     = ""
+  type        = string
+  description = "The schedule to use when scaling up the number of EC2 instances to their normal desired level."
+}
+
 # Certificates
 variable "ssl_certificate_id" {
   type        = string


### PR DESCRIPTION
Scale down the cluster (ASG) to 0 instances from 8pm to 6am on staging only.

Resolves:
https://companieshouse.atlassian.net/browse/CC-795