### PR TITLE
Reference ecs-cluster module from terraform-modules

### DIFF
--- a/groups/infrastructure/main.tf
+++ b/groups/infrastructure/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "ecs-cluster" {
-  source = "git@github.com:companieshouse/terraform-library-ecs-cluster.git?ref=1.1.7"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.212"
 
   stack_name                 = local.stack_name
   name_prefix                = local.name_prefix


### PR DESCRIPTION
The ecs-cluster library has now been added to the terraform-modules repo and so the developer site stack has been updated to reference that new source location.

Resolves:
https://companieshouse.atlassian.net/browse/CC-806
