### PR TITLE
Bump version of ecs-cluster module to 1.0.216

### DIFF
--- a/groups/infrastructure/main.tf
+++ b/groups/infrastructure/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "ecs-cluster" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.212"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.216"
 
   stack_name                 = local.stack_name
   name_prefix                = local.name_prefix


### PR DESCRIPTION
This brings the change to use a launch template instead of a launch configuration.

Resolves:
https://companieshouse.atlassian.net/browse/CC-803