### PR TITLE
Create SNS topics for cloudwatch alerting

### DIFF
--- a/groups/infrastructure/locals.tf
+++ b/groups/infrastructure/locals.tf
@@ -5,11 +5,12 @@ locals {
 
   stack_secrets = jsondecode(data.vault_generic_secret.secrets.data_json)
 
-  application_subnet_pattern = local.stack_secrets["application_subnet_pattern"]
-  public_subnet_pattern      = local.stack_secrets["public_subnet_pattern"]
-  application_subnet_ids     = join(",", data.aws_subnets.application.ids)
-  kms_key_alias              = local.stack_secrets["kms_key_alias"]
-  vpc_name                   = local.stack_secrets["vpc_name"]
+  application_subnet_pattern  = local.stack_secrets["application_subnet_pattern"]
+  public_subnet_pattern       = local.stack_secrets["public_subnet_pattern"]
+  application_subnet_ids      = join(",", data.aws_subnets.application.ids)
+  kms_key_alias               = local.stack_secrets["kms_key_alias"]
+  vpc_name                    = local.stack_secrets["vpc_name"]
+  notify_topic_slack_endpoint = local.stack_secrets["notify_topic_slack_endpoint"]
 
   parameter_store_secrets = {
     "vpc-name"                 = local.stack_secrets["vpc_name"],

--- a/groups/infrastructure/main.tf
+++ b/groups/infrastructure/main.tf
@@ -18,23 +18,25 @@ terraform {
 }
 
 module "ecs-cluster" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.216"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-cluster?ref=1.0.218"
 
-  stack_name                 = local.stack_name
-  name_prefix                = local.name_prefix
-  environment                = var.environment
-  vpc_id                     = data.aws_vpc.vpc.id
-  subnet_ids                 = local.application_subnet_ids
-  ec2_key_pair_name          = var.ec2_key_pair_name
-  ec2_instance_type          = var.ec2_instance_type
-  ec2_image_id               = var.ec2_image_id
-  asg_max_instance_count     = var.asg_max_instance_count
-  asg_min_instance_count     = var.asg_min_instance_count
-  enable_container_insights  = var.enable_container_insights
-  asg_desired_instance_count = var.asg_desired_instance_count
-  scaledown_schedule         = var.asg_scaledown_schedule
-  scaleup_schedule           = var.asg_scaleup_schedule
-  enable_asg_autoscaling     = var.enable_asg_autoscaling
+  stack_name                  = local.stack_name
+  name_prefix                 = local.name_prefix
+  environment                 = var.environment
+  aws_profile                 = var.aws_profile
+  vpc_id                      = data.aws_vpc.vpc.id
+  subnet_ids                  = local.application_subnet_ids
+  ec2_key_pair_name           = var.ec2_key_pair_name
+  ec2_instance_type           = var.ec2_instance_type
+  ec2_image_id                = var.ec2_image_id
+  asg_max_instance_count      = var.asg_max_instance_count
+  asg_min_instance_count      = var.asg_min_instance_count
+  enable_container_insights   = var.enable_container_insights
+  asg_desired_instance_count  = var.asg_desired_instance_count
+  scaledown_schedule          = var.asg_scaledown_schedule
+  scaleup_schedule            = var.asg_scaleup_schedule
+  enable_asg_autoscaling      = var.enable_asg_autoscaling
+  notify_topic_slack_endpoint = local.notify_topic_slack_endpoint
 }
 
 module "secrets" {


### PR DESCRIPTION
Reference new version 1.0.218 of ecs-cluster module to create the SNS topics for CloudWatch alerting functionality.

Makes use of a new stack level secret, `notify_topic_slack_endpoint`, that contains the Slack endpoint URL.

Resolves:
https://companieshouse.atlassian.net/browse/CC-804