### PR TITLE
Scale staging and live EC2 instance count down to zero

### DIFF
--- a/groups/infrastructure/profiles/live-eu-west-2/live/vars
+++ b/groups/infrastructure/profiles/live-eu-west-2/live/vars
@@ -17,5 +17,5 @@ ec2_key_pair_name = "ch-aws-live"
 # EC2 sizing and scaling options
 ec2_instance_type = "t3.medium"
 asg_max_instance_count = 6 # allow live to scale up to 2 instances per az if required
-asg_min_instance_count = 0 # keep live multi-az by default
-asg_desired_instance_count = 0 # keep live multi-az by default
+asg_min_instance_count = 0 # scaled to zero as all services use fargate
+asg_desired_instance_count = 0 # scaled to zero as all services use fargate

--- a/groups/infrastructure/profiles/live-eu-west-2/live/vars
+++ b/groups/infrastructure/profiles/live-eu-west-2/live/vars
@@ -17,5 +17,5 @@ ec2_key_pair_name = "ch-aws-live"
 # EC2 sizing and scaling options
 ec2_instance_type = "t3.medium"
 asg_max_instance_count = 6 # allow live to scale up to 2 instances per az if required
-asg_min_instance_count = 3 # keep live multi-az by default
-asg_desired_instance_count = 3 # keep live multi-az by default
+asg_min_instance_count = 0 # keep live multi-az by default
+asg_desired_instance_count = 0 # keep live multi-az by default

--- a/groups/infrastructure/profiles/staging-eu-west-2/staging/vars
+++ b/groups/infrastructure/profiles/staging-eu-west-2/staging/vars
@@ -16,5 +16,5 @@ ec2_key_pair_name = "ch-aws-staging"
 # EC2 sizing and scaling options
 ec2_instance_type = "t3.medium"
 asg_max_instance_count = 3 # allow staging to scale up
-asg_min_instance_count = 0 # allow staging to scale down
-asg_desired_instance_count = 0 # keep staging small by default
+asg_min_instance_count = 0 # scaled to zero as all services use fargate
+asg_desired_instance_count = 0 # scaled to zero as all services use fargate

--- a/groups/infrastructure/profiles/staging-eu-west-2/staging/vars
+++ b/groups/infrastructure/profiles/staging-eu-west-2/staging/vars
@@ -16,7 +16,5 @@ ec2_key_pair_name = "ch-aws-staging"
 # EC2 sizing and scaling options
 ec2_instance_type = "t3.medium"
 asg_max_instance_count = 3 # allow staging to scale up
-asg_min_instance_count = 1 # allow staging to scale down
-asg_desired_instance_count = 2 # keep staging small by default
-asg_scaledown_schedule = "00 20 * * 1-7"
-asg_scaleup_schedule = "00 06 * * 1-7"
+asg_min_instance_count = 0 # allow staging to scale down
+asg_desired_instance_count = 0 # keep staging small by default


### PR DESCRIPTION
All services in the developer-site ECS cluster use Fargate, so this sets the number of EC2 instances to zero, as they are not currently needed (there is currently 1 in staging, and 3 running in live).

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2859