### PR TITLE
Add dev site to rebel1, allow for mongo 7 testing

### DIFF
--- a/groups/infrastructure/profiles/development-eu-west-2/rebel1/vars
+++ b/groups/infrastructure/profiles/development-eu-west-2/rebel1/vars
@@ -1,0 +1,20 @@
+aws_bucket = "development-eu-west-2.terraform-state.ch.gov.uk"
+remote_state_bucket = "ch-development-terraform-state-london"
+environment = "rebel1"
+deploy_to = "development"
+state_prefix = "env:/development"
+aws_profile = "development-eu-west-2"
+enable_container_insights = true
+
+# Certificate for https access through ALB
+ssl_certificate_id = "arn:aws:acm:eu-west-2:169942020521:certificate/8d7db053-7416-4e56-946b-762d0a34c899"
+zone_id = "Z2KSI4Z5ZN9NT0"
+external_top_level_domain = ".rebel1.aws.chdev.org"
+
+ec2_key_pair_name = "chs-rebel1"
+
+# EC2 sizing and scaling options
+ec2_instance_type = "t3.medium"
+asg_max_instance_count = 2 # allow rebel1 to scale up
+asg_min_instance_count = 0 # allow rebel1 to scale down to 0
+asg_desired_instance_count = 0 # keep rebel1 at 0 instance count until ec2 launch type service is needed


### PR DESCRIPTION
Cluster needs some refactoring, this will come separate to this deployment

See https://github.com/companieshouse/ci-pipelines/pull/4350 for reasons